### PR TITLE
Add static API url

### DIFF
--- a/src/ApiCommunicationsWrapper/Services/APIFunctions.ts
+++ b/src/ApiCommunicationsWrapper/Services/APIFunctions.ts
@@ -1,3 +1,5 @@
+import {API_URL} from "../vars";
+
 require("dotenv").config();
 
 import {
@@ -18,7 +20,7 @@ export namespace APIFunctionalities {
     requestProperties: RequestProperties,
   ): Promise<DocHorizonResponse> {
     const { endpoint, params, body } = requestProperties;
-    let url = `${process.env.API_URL}${endpoint.url}`;
+    let url = `${process.env.API_URL ?? API_URL}${endpoint.url}`;
 
     if (params?.PathParams) {
       url = processPathParameters(url, params.PathParams);

--- a/src/ApiCommunicationsWrapper/vars.ts
+++ b/src/ApiCommunicationsWrapper/vars.ts
@@ -1,0 +1,1 @@
+export const API_URL = 'https://dochorizon.klippa.com'


### PR DESCRIPTION
- Added static api url in vars file
- Changed line to determine whether to use the static url or another one depending on the prescence of an API_URL variable in a .env file (so the standard is the static api url, unless someone has an api_url var in a .env file) 